### PR TITLE
No subclass constructor override for methods

### DIFF
--- a/polyfill.test.js
+++ b/polyfill.test.js
@@ -210,6 +210,31 @@ tape(`Array.prototype.withAt out of bounds`, (t) => {
     t.end();
 });
 
+tape(`Array does not use Symbol.species for the new methods`, (t) => {
+    class SubClass extends Array {}
+
+    const orig = new SubClass([1, 2, 3]);
+
+    function assertType(arr) {
+        t.equal(arr instanceof SubClass, false);
+        t.equal(arr instanceof Array, true);
+    }
+
+    assertType(orig.withAt(0, 0));
+    assertType(orig.withAt(0, 0));
+    assertType(orig.withCopiedWithin(0, 0, 0));
+    assertType(orig.withFilled(0));
+    assertType(orig.withPopped());
+    assertType(orig.withPushed(0));
+    assertType(orig.withReversed());
+    assertType(orig.withShifted());
+    assertType(orig.withSorted());
+    assertType(orig.withSpliced(0, 0));
+    assertType(orig.withUnshifted(0));
+
+    t.end();
+});
+
 tape("Array.prototype[Symbol.unscopables]", (t) => {
     const marker = Symbol();
     const copiedWithin = marker;
@@ -415,6 +440,32 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         t.throws(() => {
             orig.withAt(idx, val);
         }, RangeError);
+
+        t.end();
+    });
+
+    tape(`${TypedArray.name} does not use Symbol.species for the new methods`, (t) => {
+        class SubClass extends TypedArray {}
+
+        function assertType(arr) {
+            t.equal(arr instanceof SubClass, false);
+            t.equal(arr instanceof TypedArray, true);
+        }
+
+        /** @type {Uint8Array} */
+        // @ts-ignore
+        const orig = new SubClass([1, 2, 3]);
+
+        assertType(orig.withAt(0, 0));
+        assertType(orig.withCopiedWithin(0, 0, 0));
+        assertType(orig.withFilled(0));
+        assertType(orig.withPopped());
+        assertType(orig.withPushed(0));
+        assertType(orig.withReversed());
+        assertType(orig.withShifted());
+        assertType(orig.withSorted());
+        assertType(orig.withSpliced(0, 0));
+        assertType(orig.withUnshifted(0));
 
         t.end();
     });

--- a/spec.html
+++ b/spec.html
@@ -26,7 +26,7 @@ contributors: Robin Ricard, Ashley Claymore
                 <emu-alg>
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_len_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
                     1. If _relativeTarget_ is -&infin;, let _actualTarget_ be 0.
                     1. Else if _relativeTarget_ &lt; 0, let _actualTarget_ be max(_len_ + _relativeTarget_, 0).
@@ -70,7 +70,7 @@ contributors: Robin Ricard, Ashley Claymore
                 <emu-alg>
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_len_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
                     1. If _relativeStart_ is -&infin;, let _actualStart_ be 0.
                     1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
@@ -107,7 +107,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
                     1. Let _newLen_ be max(_len_ - 1, 0).
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_newLen_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_newLen_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _newLen_,
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -128,7 +128,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _itemCount_ be the number of elements in _items_.
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
                     1. let _newLen_ be _len_ + _itemCount_.
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_newLen_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_newLen_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _len_,
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -152,7 +152,7 @@ contributors: Robin Ricard, Ashley Claymore
                 <emu-alg>
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_len_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _len_,
                         1. Let _from_ be ! ToString(𝔽(_len_ - _k_ - 1)).
@@ -173,7 +173,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
                     1. Let _newLen_ be max(_len_ - 1, 0).
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_newLen_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_newLen_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _newLen_,
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -202,7 +202,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Append _kValue_ to _items_.
                         1. Set _k_ to _k_ + 1.
                     1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_len_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _j_ be 0.
                     1. For each element _E_ of _items_, do
                         1. Let _Pj_ be ! ToString(𝔽(_j_)).
@@ -235,7 +235,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _dc_ be ? ToIntegerOrInfinity(_deleteCount_).
                         1. Let _actualDeleteCount_ be the result of clamping _dc_ between 0 and _len_ - _actualStart_.
                     1. Let _newLen_ be _len_ + _insert_Count_ - _actualDeleteCount_.
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_newLen_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_newLen_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _newLen_,
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -267,7 +267,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _O_ be the *this* value.
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
                     1. Let _newLen_ be _len_ + _itemCount_.
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_newLen_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_newLen_)).
                     1. Let _k_ be 0.
                     1. For each element _E_ of _items_, do
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -298,7 +298,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. If _index_ &lt; 0, let _actualIndex_ be _len_ + _index_.
                     1. Else, let _actualIndex_ be _index_.
                     1. If _actualIndex_ &lt; 0, throw a *RangeError* exception.
-                    1. Let _A_ be ? ArraySpeciesCreate(_O_, 𝔽(_len_)).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _len_,
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).

--- a/spec.html
+++ b/spec.html
@@ -349,6 +349,22 @@ contributors: Robin Ricard, Ashley Claymore
         <emu-clause id="sec-abstract-operations-for-typedarray-objects">
             <h1>Abstract Operations for TypedArray Objects</h1>
 
+            <emu-clause id="typedarray-species-create" aoid="TypedArraySpeciesCreate">
+                <h1>TypedArraySpeciesCreate ( _exemplar_, _argumentList_ <ins>[ , _noSpeciesOverride_ ] </ins> )</h1>
+                <p>The abstract operation TypedArraySpeciesCreate takes arguments _exemplar_, _argumentList_, <ins>and optional argument _noSpeciesOverride_ </ins>. It is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps when called:</p>
+                <emu-alg>
+                1. Assert: _exemplar_ is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
+                1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _exemplar_.[[TypedArrayName]].
+                1. <ins>If _noSpeciesOverride_ is *true*, let _constructor_ be _defaultConstructor_.</ins>
+                1. <ins>Else, Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_)</ins>.
+                1. <del>Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).</del>
+                1. Let _result_ be ? TypedArrayCreate(_constructor_, _argumentList_).
+                1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
+                1. If _result_.[[ContentType]] &ne; _exemplar_.[[ContentType]], throw a *TypeError* exception.
+                1. Return _result_.
+                </emu-alg>
+            </emu-clause>
+
             <emu-clause id="typedarray-copy-range" aoid="TypedArrayCopyRange">
                 <h1>TypedArrayCopyRange ( _src_, _target_, _start_, _limit_ )</h1>
                 <p>The abstract operation TypedArrayCopyRange takes arguments _src_ (a TypedArray object), _target_ (a TypedArray object), _start_ (a non-negative integer), and _limit_ (a non-negative integer). It performs the following steps when called:</p>
@@ -359,9 +375,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Assert: _limit_ is a non-negative integer.
                     1. Assert: _limit_ is &le; the length of _src_.
                     1. Assert: _limit_ is &le; the length of _target_.
-                    1. Let _srcConstructor_ be ? SpeciesConstructor(_src_, _defaultConstructor_).
-                    1. Let _targetConstructor_ be ? SpeciesConstructor(_target_, _defaultConstructor_).
-                    1. Assert: _srcConstructor_ is _targetConstructor_.
+                    1. Assert: _src_.[[TypedArrayName]] is _target_.[[TypedArrayName]].
                     1. Let _k_ be _start_.
                     1. Repeat, while _k_ &lt; _limit_,
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -387,7 +401,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _O_ be ? ToObject(*this* value).
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be ? LengthOfArrayLike(_O_).
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
                         1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
                         1. If _relativeTarget_ is -&infin;, let _actualTarget_ be 0.
                         1. Else if _relativeTarget_ &lt; 0, let _actualTarget_ be max(_len_ + _relativeTarget_, 0).
@@ -426,7 +440,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. If _O_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
                         1. Otherwise, set _value_ to ? ToNumber(_value_).
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
                         1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
                         1. If _relativeStart_ is -&infin;, let _actualStart_ be 0.
                         1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
@@ -456,7 +470,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. Let _newLen_ be max(_len_ - 1, 0).
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;, *true*).
                         1. Perform ? TypedArrayCopyRange(_O_, _A_, *0*<sub>𝔽</sub>, 𝔽(_newLen_)).
                         1. Return _A_.
                     </emu-alg>
@@ -473,7 +487,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. Let _newLen_ be _len_ + _itemCount_.
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;, *true*).
                         1. Perform ? TypedArrayCopyRange(_O_, _A_, *0*<sub>𝔽</sub>, 𝔽(_len_)).
                         1. Let _k_ be _len_.
                         1. For each element _E_ of _items_, do
@@ -494,7 +508,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _O_ be the *this* value.
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _length_ be _O_.[[ArrayLength]].
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_length_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_length_) &raquo;, *true*).
                         1. Let _k_ be 0.
                         1. Repeat, while _k_ &lt; _length_,
                             1. Let _from_ be ! ToString(𝔽(_length_ - _k_ - 1)).
@@ -516,7 +530,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. Let _newLen_ be max(_len_ - 1, 0).
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;, *true*).
                         1. Let _k_ be 0.
                         1. Repeat, while _k_ &lt; _newLen_,
                             1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -546,7 +560,7 @@ contributors: Robin Ricard, Ashley Claymore
                             1. Append _kValue_ to _items_.
                             1. Set _k_ to _k_ + 1.
                         1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
                         1. Let _j_ be 0.
                         1. For each element _E_ of _items_, do
                             1. Let _Pj_ be ! ToString(𝔽(_j_)).
@@ -598,7 +612,7 @@ contributors: Robin Ricard, Ashley Claymore
                             1. Let _dc_ be ? ToIntegerOrInfinity(_deleteCount_).
                             1. Let _actualDeleteCount_ be the result of clamping _dc_ between 0 and _len_ - _actualStart_.
                         1. Let _newLen_ be _len_ + _insert_Count_ - _actualDeleteCount_.
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;, *true*).
                         1. Perform ? TypedArrayCopyRange(_O_, _A_, *0*<sub>𝔽</sub>, 𝔽(_actualStart_)).
                         1. Let _k_ be _actualStart_.
                         1. For each element _E_ of _items_, do
@@ -626,7 +640,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. Let _newLen_ be _len_ + _itemCount_.
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_newLen_) &raquo;, *true*).
                         1. Let _k_ be 0.
                         1. For each element _E_ of _items_, do
                             1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -657,7 +671,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. If _index_ &lt; 0, let _actualIndex_ be _len_ + _index_.
                         1. Else, let _actualIndex_ be _index_.
                         1. If ! IsValidIntegerIndex(_O_, _actualIndex_) is *false*, throw a *RangeError* exception.
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;).
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
                         1. Let _k_ be 0.
                         1. Repeat, while _k_ &lt; _len_,
                             1. Let _Pk_ be ! ToString(𝔽(_k_)).


### PR DESCRIPTION
This PR updates the polyfill and spec text so that the created collections will always be one of the built in types. Not looking up `Symbol.species` on the instance. Tests have also been added to validate the polyfill.

fixes #33 
