### PR TITLE
improved spec for Array.prototype.withSpliced

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -90,12 +90,11 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _newLen_ be _len_ + _insert_Count_ - _actualDeleteCount_.
                     1. Let _A_ be ? ArrayCreate(𝔽(_newLen_)).
                     1. Let _k_ be 0.
-                    1. Repeat, while _k_ &lt; _newLen_,
+                    1. Repeat, while _k_ &lt; _actualStart_,
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
                         1. Let _kValue_ be ? Get(_O_, _Pk_).
                         1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _kValue_).
                         1. Set _k_ to _k_ + 1.
-                    1. Let _k_ be _actualStart_.
                     1. For each element _E_ of _items_, do
                         1. Let _Pk_ be ! ToString(𝔽(_k_)).
                         1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _E_).


### PR DESCRIPTION
Brings the spec for `Array.prototype.withSpliced` inline with `TypedArray` and the polyfill.

Thanks to @catamorphism for spotting this 

fixes #43
