### PR TITLE
run tests in gh workflow

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Install dev deps
       run: npm install
     - name: Test the polyfill
-      run: npm run build
+      run: npm run test


### PR DESCRIPTION
Noticed a typo in the actions, we run `build` twice instead of `build` and `test`.