### PR TITLE
use 'to' prefix for method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ This proposal is currently at [Stage 2].
 
 This proposal introduces the following function properties to `Array.prototype`:
 
-- `Array.prototype.withReversed() -> Array`
-- `Array.prototype.withSorted(compareFn) -> Array`
-- `Array.prototype.withSpliced(start, deleteCount, ...items) -> Array`
-- `Array.prototype.withAt(index, value) -> Array`
+- `Array.prototype.toReversed() -> Array`
+- `Array.prototype.toSorted(compareFn) -> Array`
+- `Array.prototype.toSpliced(start, deleteCount, ...items) -> Array`
+- `Array.prototype.with(index, value) -> Array`
 
 All of those methods keep the target Array untouched and returns a copy of it with the change performed instead.
 
 They will also be added to TypedArrays:
 
-- `TypedArray.prototype.withReversed() -> TypedArray`
-- `TypedArray.prototype.withSorted(compareFn) -> TypedArray`
-- `TypedArray.prototype.withSpliced(start, deleteCount, ...items) -> TypedArray`
-- `TypedArray.prototype.withAt(index, value) -> TypedArray`
+- `TypedArray.prototype.toReversed() -> TypedArray`
+- `TypedArray.prototype.toSorted(compareFn) -> TypedArray`
+- `TypedArray.prototype.toSpliced(start, deleteCount, ...items) -> TypedArray`
+- `TypedArray.prototype.with(index, value) -> TypedArray`
 
 These methods will then be avaliable on subclasses of `TypedArray`. i.e. the following:
 
@@ -61,15 +61,15 @@ These methods will then be avaliable on subclasses of `TypedArray`. i.e. the fol
 
 ```js
 const sequence = [1, 2, 3];
-sequence.withReversed(); // => [3, 2, 1]
+sequence.toReversed(); // => [3, 2, 1]
 sequence; // => [1, 2, 3]
 
 const outOfOrder = new Uint8Array([3, 1, 2]);
-outOfOrder.withSorted(); // => Uint8Array [1, 2, 3]
+outOfOrder.toSorted(); // => Uint8Array [1, 2, 3]
 outOfOrder; // => Uint8Array [3, 1, 2]
 
 const correctionNeeded = [1, 1, 3];
-correctionNeeded.withAt(1, 2); // => [1, 2, 3]
+correctionNeeded.with(1, 2); // => [1, 2, 3]
 correctionNeeded; // => [1, 1, 3]
 ```
 

--- a/polyfill.d.ts
+++ b/polyfill.d.ts
@@ -1,72 +1,72 @@
 declare global {
     interface Array<T> {
-        withAt(index: number, value: T): T[];
-        withReversed(): T[];
-        withSorted(compareFn?: (a: T, b: T) => number): T[];
-        withSpliced(start: number, deleteCount?: number, ...values: T[]): T[];
+        with(index: number, value: T): T[];
+        toReversed(): T[];
+        toSorted(compareFn?: (a: T, b: T) => number): T[];
+        toSpliced(start: number, deleteCount?: number, ...values: T[]): T[];
     }
 
     interface Int8Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Uint8Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Uint8ClampedArray {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Int16Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Uint16Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Int32Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Uint32Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Float32Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 
     interface Float64Array {
-        withAt(index: number, value: number): this;
-        withReversed(): this;
-        withSorted(compareFn?: (a: number, b: number) => number): this;
-        withSpliced(start: number, deleteCount?: number, ...values: number[]): this;
+        with(index: number, value: number): this;
+        toReversed(): this;
+        toSorted(compareFn?: (a: number, b: number) => number): this;
+        toSpliced(start: number, deleteCount?: number, ...values: number[]): this;
     }
 }
 export {};

--- a/polyfill.js
+++ b/polyfill.js
@@ -96,7 +96,7 @@
         }
     }
 
-    /** @type {Array["withReversed"]} */
+    /** @type {Array["toReversed"]} */
     function arrayReversed() {
         const o = Object(this);
         const len = lengthOfArrayLike(o);
@@ -105,7 +105,7 @@
         return a;
     }
 
-    /** @type {TypedArray["withReversed"]} */
+    /** @type {TypedArray["toReversed"]} */
     function typedArrayReversed() {
         const o = assertTypedArray(this);
         const len = o.length;
@@ -114,7 +114,7 @@
         return a;
     }
 
-    /** @type {Array["withSorted"]} */
+    /** @type {Array["toSorted"]} */
     function arraySorted(compareFn) {
         if (compareFn !== void 0 && typeof compareFn !== "function") {
             throw new TypeError();
@@ -127,7 +127,7 @@
         return a;
     }
 
-    /** @type {TypedArray["withSorted"]} */
+    /** @type {TypedArray["toSorted"]} */
     function typedArraySorted(compareFn) {
         if (compareFn !== void 0 && typeof compareFn !== "function") {
             throw new TypeError();
@@ -185,7 +185,7 @@
         }
     }
 
-    /** @type {Array["withSpliced"]} */
+    /** @type {Array["toSpliced"]} */
     function arraySpliced(start, deleteCount, ...values) {
         const o = Object(this);
         const len = lengthOfArrayLike(o);
@@ -195,7 +195,7 @@
         return a;
     }
 
-    /** @type {TypedArray["withSpliced"]} */
+    /** @type {TypedArray["toSpliced"]} */
     function typedArraySpliced(start, deleteCount, ...values) {
         const o = assertTypedArray(this);
         const len = o.length;
@@ -205,8 +205,8 @@
         return a;
     }
 
-    /** @type {Array["withAt"]} */
-    function arrayWithAt(index, value) {
+    /** @type {Array["with"]} */
+    function arrayWith(index, value) {
         const o = Object(this);
         const len = lengthOfArrayLike(o);
         const actualIndex = index < 0 ? len + index : index;
@@ -221,8 +221,8 @@
         return a;
     }
 
-    /** @type {TypedArray["withAt"]} */
-    function typedArrayWithAt(index, value) {
+    /** @type {TypedArray["with"]} */
+    function typedArrayWith(index, value) {
         const o = assertTypedArray(this);
         const len = o.length;
         const actualIndex = index < 0 ? len + index : index;
@@ -258,22 +258,25 @@
     }
 
     const arrayMethods = {
-        withAt: arrayWithAt,
-        withReversed: arrayReversed,
-        withSorted: arraySorted,
-        withSpliced: arraySpliced,
+        with: arrayWith,
+        toReversed: arrayReversed,
+        toSorted: arraySorted,
+        toSpliced: arraySpliced,
     };
 
     addToPrototype(arrayPrototype, arrayMethods);
 
     for (const method of Object.keys(arrayMethods)) {
+        if (method === 'with') {
+            continue; // 'with' is already a keyword
+        }
         arrayPrototype[Symbol.unscopables][method] = true;
     }
 
     addToPrototype(typedArrayPrototype, {
-        withAt: typedArrayWithAt,
-        withReversed: typedArrayReversed,
-        withSorted: typedArraySorted,
-        withSpliced: typedArraySpliced,
+        with: typedArrayWith,
+        toReversed: typedArrayReversed,
+        toSorted: typedArraySorted,
+        toSpliced: typedArraySpliced,
     });
 })(Array.prototype, Object.getPrototypeOf(Int8Array.prototype));

--- a/polyfill.test.js
+++ b/polyfill.test.js
@@ -2,7 +2,7 @@
 require("./polyfill.js");
 const tape = require("tape");
 
-tape("Array.prototype.withReversed works with array-like values", (t) => {
+tape("Array.prototype.toReversed works with array-like values", (t) => {
     const orig = {
         0: 3,
         1: 2,
@@ -11,7 +11,7 @@ tape("Array.prototype.withReversed works with array-like values", (t) => {
     };
     const expected = [1, 2, 3];
 
-    const copy = Array.prototype.withReversed.call(orig);
+    const copy = Array.prototype.toReversed.call(orig);
 
     t.deepEqual(copy, expected);
     t.notEqual(orig, copy);
@@ -19,11 +19,11 @@ tape("Array.prototype.withReversed works with array-like values", (t) => {
     t.end();
 });
 
-tape("Array.prototype.withReversed", (t) => {
+tape("Array.prototype.toReversed", (t) => {
     const orig = [3, 2, 1];
     const expected = [1, 2, 3];
 
-    const copy = orig.withReversed();
+    const copy = orig.toReversed();
 
     t.deepEqual(copy, expected);
     t.notEqual(orig, copy);
@@ -31,11 +31,11 @@ tape("Array.prototype.withReversed", (t) => {
     t.end();
 });
 
-tape("Array.prototype.withSorted", (t) => {
+tape("Array.prototype.toSorted", (t) => {
     const orig = [3, 1, 2];
     const expected = [1, 2, 3];
 
-    const copy = orig.withSorted();
+    const copy = orig.toSorted();
 
     t.deepEqual(copy, expected);
     t.notEqual(orig, copy);
@@ -43,14 +43,14 @@ tape("Array.prototype.withSorted", (t) => {
     t.end();
 });
 
-tape("Array.prototype.withSorted(compareFn)", (t) => {
+tape("Array.prototype.toSorted(compareFn)", (t) => {
     const orig = [3, 1, 2];
     const expected = [3, 2, 1];
     function compareFn(a, b) {
         return a > b ? -1 : 1;
     }
 
-    const copy = orig.withSorted(compareFn);
+    const copy = orig.toSorted(compareFn);
 
     t.deepEqual(copy, expected);
     t.notEqual(orig, copy);
@@ -58,14 +58,14 @@ tape("Array.prototype.withSorted(compareFn)", (t) => {
     t.end();
 });
 
-tape("Array.prototype.withSpliced", (t) => {
+tape("Array.prototype.toSpliced", (t) => {
     const orig = [1, -1, 0, -1, 4];
     const expected = [1, 2, 3, 4];
     const idx = 1;
     const delNum = 3;
     const ins = [2, 3];
 
-    const copy = orig.withSpliced(idx, delNum, ...ins);
+    const copy = orig.toSpliced(idx, delNum, ...ins);
 
     t.deepEqual(copy, expected);
     t.notEqual(orig, copy);
@@ -73,13 +73,13 @@ tape("Array.prototype.withSpliced", (t) => {
     t.end();
 });
 
-tape("Array.prototype.withAt", (t) => {
+tape("Array.prototype.with", (t) => {
     const orig = [1, 1, 3];
     const expected = [1, 2, 3];
     const idx = 1;
     const val = 2;
 
-    const copy = orig.withAt(idx, val);
+    const copy = orig.with(idx, val);
 
     t.deepEqual(copy, expected);
     t.notEqual(orig, copy);
@@ -87,13 +87,13 @@ tape("Array.prototype.withAt", (t) => {
     t.end();
 });
 
-tape(`Array.prototype.withAt negativeIndex`, (t) => {
+tape(`Array.prototype.with negativeIndex`, (t) => {
     const orig = [1, 2, 2];
     const expected = [1, 2, 3];
     const idx = -1;
     const val = 3;
 
-    const copy = orig.withAt(idx, val);
+    const copy = orig.with(idx, val);
 
     t.deepEqual(copy, expected);
     t.notEqual(orig, copy);
@@ -101,20 +101,20 @@ tape(`Array.prototype.withAt negativeIndex`, (t) => {
     t.end();
 });
 
-tape(`Array.prototype.withAt out of bounds`, (t) => {
+tape(`Array.prototype.with out of bounds`, (t) => {
     const orig = [1, 2, 2];
     const idx = 3;
     const val = 4;
 
     t.throws(() => {
-        orig.withAt(idx, val);
+        orig.with(idx, val);
     }, RangeError);
 
     t.end();
 });
 
 tape(`Array does not use Symbol.species for the new methods`, (t) => {
-    class SubClass extends Array {}
+    class SubClass extends Array { }
 
     const orig = new SubClass([1, 2, 3]);
 
@@ -123,16 +123,17 @@ tape(`Array does not use Symbol.species for the new methods`, (t) => {
         t.equal(arr instanceof Array, true);
     }
 
-    assertType(orig.withAt(0, 0));
-    assertType(orig.withReversed());
-    assertType(orig.withSorted());
-    assertType(orig.withSpliced(0, 0));
+    assertType(orig.with(0, 0));
+    assertType(orig.toReversed());
+    assertType(orig.toSorted());
+    assertType(orig.toSpliced(0, 0));
 
     t.end();
 });
 
 tape("Array.prototype[Symbol.unscopables]", (t) => {
-    const methodNames = ['withAt', 'withReversed', 'withSorted', 'withSpliced'];
+    const methodNames = ['toReversed', 'toSorted', 'toSpliced']; // 'with' is omitted as it is a keyword
+    t.plan(6);
 
     // ensure we are checking the correct methods names, otherwise test will always pass, regardless of Symbol.unscopables
     for (const method of methodNames) {
@@ -140,10 +141,9 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
     }
 
     const marker = Symbol();
-    const withAt = marker;
-    const withReversed = marker;
-    const withSorted = marker;
-    const withSpliced = marker;
+    const toReversed = marker;
+    const toSorted = marker;
+    const toSpliced = marker;
 
     // @ts-expect-error: 'with' is unsupported
     with ([]) {
@@ -165,11 +165,11 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
     Float32Array,
     Float64Array
 ].forEach((TypedArray) => {
-    tape(`${TypedArray.name}.prototype.withReversed`, (t) => {
+    tape(`${TypedArray.name}.prototype.toReversed`, (t) => {
         const orig = new TypedArray([3, 2, 1]);
         const expected = new TypedArray([1, 2, 3]);
 
-        const copy = orig.withReversed();
+        const copy = orig.toReversed();
 
         t.deepEqual(copy, expected);
         t.notEqual(orig, copy);
@@ -177,11 +177,11 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         t.end();
     });
 
-    tape(`${TypedArray.name}.prototype.withSorted`, (t) => {
+    tape(`${TypedArray.name}.prototype.toSorted`, (t) => {
         const orig = new TypedArray([3, 1, 2]);
         const expected = new TypedArray([1, 2, 3]);
 
-        const copy = orig.withSorted();
+        const copy = orig.toSorted();
 
         t.deepEqual(copy, expected);
         t.notEqual(orig, copy);
@@ -189,14 +189,14 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         t.end();
     });
 
-    tape(`${TypedArray.name}.prototype.withSorted(compareFn)`, (t) => {
+    tape(`${TypedArray.name}.prototype.toSorted(compareFn)`, (t) => {
         const orig = new TypedArray([3, 1, 2]);
         const expected = new TypedArray([3, 2, 1]);
         function compareFn(a, b) {
             return a > b ? -1 : 1;
         }
 
-        const copy = orig.withSorted(compareFn);
+        const copy = orig.toSorted(compareFn);
 
         t.deepEqual(copy, expected);
         t.notEqual(orig, copy);
@@ -204,14 +204,14 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         t.end();
     });
 
-    tape(`${TypedArray.name}.prototype.withSpliced`, (t) => {
+    tape(`${TypedArray.name}.prototype.toSpliced`, (t) => {
         const orig = new TypedArray([1, -1, 0, -1, 4]);
         const expected = new TypedArray([1, 2, 3, 4]);
         const idx = 1;
         const delNum = 3;
         const ins = [2, 3];
 
-        const copy = orig.withSpliced(idx, delNum, ...ins);
+        const copy = orig.toSpliced(idx, delNum, ...ins);
 
         t.deepEqual(copy, expected);
         t.notEqual(orig, copy);
@@ -219,13 +219,13 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         t.end();
     });
 
-    tape(`${TypedArray.name}.prototype.withAt`, (t) => {
+    tape(`${TypedArray.name}.prototype.with`, (t) => {
         const orig = new TypedArray([1, 1, 3]);
         const expected = new TypedArray([1, 2, 3]);
         const idx = 1;
         const val = 2;
 
-        const copy = orig.withAt(idx, val);
+        const copy = orig.with(idx, val);
 
         t.deepEqual(copy, expected);
         t.notEqual(orig, copy);
@@ -233,13 +233,13 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         t.end();
     });
 
-    tape(`${TypedArray.name}.prototype.withAt negativeIndex`, (t) => {
+    tape(`${TypedArray.name}.prototype.with negativeIndex`, (t) => {
         const orig = new TypedArray([1, 2, 2]);
         const expected = new TypedArray([1, 2, 3]);
         const idx = -1;
         const val = 3;
 
-        const copy = orig.withAt(idx, val);
+        const copy = orig.with(idx, val);
 
         t.deepEqual(copy, expected);
         t.notEqual(orig, copy);
@@ -247,20 +247,20 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         t.end();
     });
 
-    tape(`${TypedArray.name}.prototype.withAt out of bounds`, (t) => {
+    tape(`${TypedArray.name}.prototype.with out of bounds`, (t) => {
         const orig = new TypedArray([1, 2, 2]);
         const idx = 3;
         const val = 4;
 
         t.throws(() => {
-            orig.withAt(idx, val);
+            orig.with(idx, val);
         }, RangeError);
 
         t.end();
     });
 
     tape(`${TypedArray.name} does not use Symbol.species for the new methods`, (t) => {
-        class SubClass extends TypedArray {}
+        class SubClass extends TypedArray { }
 
         function assertType(arr) {
             t.equal(arr instanceof SubClass, false);
@@ -271,10 +271,10 @@ tape("Array.prototype[Symbol.unscopables]", (t) => {
         // @ts-ignore
         const orig = new SubClass([1, 2, 3]);
 
-        assertType(orig.withAt(0, 0));
-        assertType(orig.withReversed());
-        assertType(orig.withSorted());
-        assertType(orig.withSpliced(0, 0));
+        assertType(orig.with(0, 0));
+        assertType(orig.toReversed());
+        assertType(orig.toSorted());
+        assertType(orig.toSpliced(0, 0));
 
         t.end();
     });

--- a/spec.html
+++ b/spec.html
@@ -18,10 +18,10 @@ contributors: Robin Ricard, Ashley Claymore
         <emu-clause id="sec-properties-of-the-array-prototype-object">
             <h1>Properties of the Array Prototype Object</h1>
 
-            <emu-clause id="sec-array.prototype.withReversed">
-                <h1>Array.prototype.withReversed ( )</h1>
+            <emu-clause id="sec-array.prototype.toReversed">
+                <h1>Array.prototype.toReversed ( )</h1>
 
-                <p>When the *withReversed* method is called, the following steps are taken:</p>
+                <p>When the *toReversed* method is called, the following steps are taken:</p>
 
                 <emu-alg>
                     1. Let _O_ be ? ToObject(*this* value).
@@ -38,10 +38,10 @@ contributors: Robin Ricard, Ashley Claymore
                 </emu-alg>
             </emu-clause>
 
-            <emu-clause id="sec-array.prototype.withSorted">
-                <h1>Array.prototype.withSorted ( _compareFn_ )</h1>
+            <emu-clause id="sec-array.prototype.toSorted">
+                <h1>Array.prototype.toSorted ( _compareFn_ )</h1>
 
-                <p>When the *withSorted* method is called, the following steps are taken:</p>
+                <p>When the *toSorted* method is called, the following steps are taken:</p>
 
                 <emu-alg>
                     1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
@@ -65,10 +65,10 @@ contributors: Robin Ricard, Ashley Claymore
                 </emu-alg>
             </emu-clause>
 
-            <emu-clause id="sec-array.prototype.withSpliced">
-                <h1>Array.prototype.withSpliced ( _start_, _deleteCount_, ..._items_ )</h1>
+            <emu-clause id="sec-array.prototype.toSpliced">
+                <h1>Array.prototype.toSpliced ( _start_, _deleteCount_, ..._items_ )</h1>
 
-                <p>When the *withSpliced* method is called, the following steps are taken:</p>
+                <p>When the *toSpliced* method is called, the following steps are taken:</p>
 
                 <emu-alg>
                     1. Let _O_ be the *this* value.
@@ -109,10 +109,10 @@ contributors: Robin Ricard, Ashley Claymore
                 </emu-alg>
             </emu-clause>
 
-            <emu-clause id="sec-array.prototype.withAt">
-                <h1>Array.prototype.withAt ( _index_, _value_ )</h1>
+            <emu-clause id="sec-array.prototype.with">
+                <h1>Array.prototype.with ( _index_, _value_ )</h1>
 
-                <p>When the *withAt* method is called, the following steps are taken:</p>
+                <p>When the *with* method is called, the following steps are taken:</p>
 
                 <emu-alg>
                     1. Let _O_ be the *this* value.
@@ -149,10 +149,9 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"flatMap"*, *true*).
                     1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"includes"*, *true*).
                     1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"keys"*, *true*).
-                    1. <ins>Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"withAt"*, *true*).</ins>
-                    1. <ins>Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"withReversed"*, *true*).</ins>
-                    1. <ins>Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"withSorted"*, *true*).</ins>
-                    1. <ins>Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"withSpliced"*, *true*).</ins>
+                    1. <ins>Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"toReversed"*, *true*).</ins>
+                    1. <ins>Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"toSorted"*, *true*).</ins>
+                    1. <ins>Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"toSpliced"*, *true*).</ins>
                     1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"values"*, *true*).
                     1. Return _unscopableList_.
                 </emu-alg>
@@ -191,10 +190,10 @@ contributors: Robin Ricard, Ashley Claymore
             <emu-clause id="sec-properties-of-the-%typedarrayprototype%-object">
                 <h1>Properties of the %TypedArray% Prototype Object</h1>
 
-                <emu-clause id="sec-%typedarray%.prototype.withReversed">
-                    <h1>%TypedArray%.prototype.withReversed ( )</h1>
+                <emu-clause id="sec-%typedarray%.prototype.toReversed">
+                    <h1>%TypedArray%.prototype.toReversed ( )</h1>
 
-                    <p>When the *withReversed* method is called, the following steps are taken:</p>
+                    <p>When the *toReversed* method is called, the following steps are taken:</p>
 
                     <emu-alg>
                         1. Let _O_ be the *this* value.
@@ -212,10 +211,10 @@ contributors: Robin Ricard, Ashley Claymore
                     </emu-alg>
                 </emu-clause>
 
-                <emu-clause id="sec-%typedarray%.prototype.withSorted">
-                    <h1>%TypedArray%.prototype.withSorted ( _compareFn_ )</h1>
+                <emu-clause id="sec-%typedarray%.prototype.toSorted">
+                    <h1>%TypedArray%.prototype.toSorted ( _compareFn_ )</h1>
 
-                    <p>When the *withSorted* method is called, the following steps are taken:</p>
+                    <p>When the *toSorted* method is called, the following steps are taken:</p>
 
                     <emu-alg>
                         1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
@@ -238,7 +237,7 @@ contributors: Robin Ricard, Ashley Claymore
                             1. Set _j_ to _j_ + 1.
                         1. Return _A_.
                     </emu-alg>
-                    <p>The following version of SortCompare is used by %TypedArray%`.prototype.withSorted`.</p>
+                    <p>The following version of SortCompare is used by %TypedArray%`.prototype.toSorted`.</p>
                     <p>The abstract operation TypedArraySortCompare performs the following steps when called:</p>
                     <emu-alg>
                         1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
@@ -258,10 +257,10 @@ contributors: Robin Ricard, Ashley Claymore
                     </emu-alg>
                 </emu-clause>
 
-                <emu-clause id="sec-%typedarray%.prototype.withSpliced">
-                    <h1>%TypedArray%.prototype.withSpliced ( _start_, _deleteCount_, ..._items_ )</h1>
+                <emu-clause id="sec-%typedarray%.prototype.toSpliced">
+                    <h1>%TypedArray%.prototype.toSpliced ( _start_, _deleteCount_, ..._items_ )</h1>
 
-                    <p>When the *withSpliced* method is called, the following steps are taken:</p>
+                    <p>When the *toSpliced* method is called, the following steps are taken:</p>
 
                     <emu-alg>
                         1. Let _O_ be the *this* value.
@@ -303,10 +302,10 @@ contributors: Robin Ricard, Ashley Claymore
                     </emu-alg>
                 </emu-clause>
 
-                <emu-clause id="sec-%typedarray%.prototype.withAt">
-                    <h1>%TypedArray%.prototype.withAt ( _index_, _value_ )</h1>
+                <emu-clause id="sec-%typedarray%.prototype.with">
+                    <h1>%TypedArray%.prototype.with ( _index_, _value_ )</h1>
 
-                    <p>When the *withAt* method is called, the following steps are taken:</p>
+                    <p>When the *with* method is called, the following steps are taken:</p>
 
                     <emu-alg>
                         1. Let _O_ be the *this* value.


### PR DESCRIPTION
Updates the spec, polyfill and tests to use the names:

- `toReversed`
- `toSorted`
- `toSpliced`
- `with`

These are the names we plan to present to the committee for stage 3.

closes #10 