### PR TITLE
Cast `.with` index to a number

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -115,11 +115,10 @@ contributors: Robin Ricard, Ashley Claymore
                 <emu-alg>
                     1. Let _O_ be the *this* value.
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
-                    1. If IsIntegralNumber(_index_) is *false*, throw a *RangeError* exception.
-                    1. If _index_ &ge; _len_, throw a *RangeError* exception.
-                    1. If _index_ &lt; 0, let _actualIndex_ be _len_ + _index_.
-                    1. Else, let _actualIndex_ be _index_.
-                    1. If _actualIndex_ &lt; 0, throw a *RangeError* exception.
+                    1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
+                    1. If _index_ &ge; 0, let _actualIndex_ be _relativeIndex_.
+                    1. Else, let _actualIndex_ be _len_ + _relativeIndex_.
+                    1. If _actualIndex_ &ge; _len_ or _actualIndex_ &lt; 0, throw a *RangeError* exception.
                     1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _len_,

--- a/spec.html
+++ b/spec.html
@@ -308,9 +308,9 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _O_ be the *this* value.
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be _O_.[[ArrayLength]].
-                        1. If IsIntegralNumber(_index_) is *false*, throw a *RangeError* exception.
-                        1. If _index_ &lt; 0, let _actualIndex_ be _len_ + _index_.
-                        1. Else, let _actualIndex_ be _index_.
+                        1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
+                        1. If _index_ &ge; 0, let _actualIndex_ be _relativeIndex_.
+                        1. Else, let _actualIndex_ be _len_ + _relativeIndex_.
                         1. If ! IsValidIntegerIndex(_O_, _actualIndex_) is *false*, throw a *RangeError* exception.
                         1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
                         1. Let _k_ be 0.


### PR DESCRIPTION
Fixes https://github.com/tc39/proposal-change-array-by-copy/issues/42

I have also made a few editorial changes:
- swapped the two branches that compute _actualIndex_, just so that they are in the same order as in `.at`
- moves the "out of range" index checks to a single place, rather than before and after computing _actualIndex_

Relevant discussion: https://github.com/tc39/proposal-relative-indexing-method/issues/50