### PR TITLE
Throw if an array is too big before sorting the values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47,6 +47,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
+                    1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _items_ be a new empty List.
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _len_,
@@ -54,7 +55,6 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _kValue_ be ? Get(_O_, _Pk_).
                         1. Append _kValue_ to _items_.
                         1. Set _k_ to _k_ + 1.
-                    1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
                     1. Let _j_ be 0.
                     1. For each element _E_ of _items_, do
@@ -218,6 +218,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _O_ be the *this* value.
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be _O_.[[ArrayLength]].
+                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
                         1. Let _items_ be a new empty List.
                         1. Let _k_ be 0.
                         1. Repeat, while _k_ &lt; _len_,
@@ -225,7 +226,6 @@ contributors: Robin Ricard, Ashley Claymore
                             1. Let _kValue_ be ? Get(_O_, _Pk_).
                             1. Append _kValue_ to _items_.
                             1. Set _k_ to _k_ + 1.
-                        1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
                         1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
                         1. Let _j_ be 0.
                         1. For each element _E_ of _items_, do

--- a/spec.html
+++ b/spec.html
@@ -54,8 +54,8 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _kValue_ be ? Get(_O_, _Pk_).
                         1. Append _kValue_ to _items_.
                         1. Set _k_ to _k_ + 1.
-                    1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
                     1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
+                    1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
                     1. Let _j_ be 0.
                     1. For each element _E_ of _items_, do
                         1. Let _Pj_ be ! ToString(𝔽(_j_)).
@@ -225,8 +225,8 @@ contributors: Robin Ricard, Ashley Claymore
                             1. Let _kValue_ be ? Get(_O_, _Pk_).
                             1. Append _kValue_ to _items_.
                             1. Set _k_ to _k_ + 1.
-                        1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
                         1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;, *true*).
+                        1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
                         1. Let _j_ be 0.
                         1. For each element _E_ of _items_, do
                             1. Let _Pj_ be ! ToString(𝔽(_j_)).


### PR DESCRIPTION
When calling the new methods on an array with more than `2**32-1` elements, they throw because it's not possible to create an array that big (it's only possible to add elements to an existing array to make it that big).

We can throw that error in `.toSorted` before calling the comparator function (NOTE: this is an observable change), because the comparator cannot stop that error from being thrown anyway.

This is an example of code whose behavior would be changed:
```js
var arrayLike = { length: 2 ** 50 };
var count = 0;
try {
  Array.prototype.toSorted.call(arrayLike, (x, y) => {
    count++;
    return 1;
  });
} catch {
  console.log(count); // logs 9007199254740992 before this PR; 0 after.
}
```

Opinions?