### PR TITLE
Define correct method property descriptors

### DIFF
--- a/polyfill.d.ts
+++ b/polyfill.d.ts
@@ -1,13 +1,13 @@
 declare global {
-	interface Array<T> {
-		with(index: number, value: T): T[];
-		toReversed(): T[];
-		toSorted(compareFn?: (a: T, b: T) => number): T[];
-		toSpliced(start: number, deleteCount?: number, ...values: T[]): T[];
-		[Symbol.unscopables]: {
-			[N in keyof typeof Array.prototype as N extends "with" ? never : N]: true;
-		};
-	}
+    interface Array<T> {
+        with(index: number, value: T): T[];
+        toReversed(): T[];
+        toSorted(compareFn?: (a: T, b: T) => number): T[];
+        toSpliced(start: number, deleteCount?: number, ...values: T[]): T[];
+        [Symbol.unscopables]: {
+            [N in keyof typeof Array.prototype as N extends "with" ? never : N]: true;
+        };
+    }
 
     interface Int8Array {
         with(index: number, value: number): this;

--- a/polyfill.d.ts
+++ b/polyfill.d.ts
@@ -1,10 +1,13 @@
 declare global {
-    interface Array<T> {
-        with(index: number, value: T): T[];
-        toReversed(): T[];
-        toSorted(compareFn?: (a: T, b: T) => number): T[];
-        toSpliced(start: number, deleteCount?: number, ...values: T[]): T[];
-    }
+	interface Array<T> {
+		with(index: number, value: T): T[];
+		toReversed(): T[];
+		toSorted(compareFn?: (a: T, b: T) => number): T[];
+		toSpliced(start: number, deleteCount?: number, ...values: T[]): T[];
+		[Symbol.unscopables]: {
+			[N in keyof typeof Array.prototype as N extends "with" ? never : N]: true;
+		};
+	}
 
     interface Int8Array {
         with(index: number, value: number): this;


### PR DESCRIPTION
They should "look like" methods:
- correct name
- name is non-writable
- no `[[Construct]]` internal slot

Fixes 28 of the failures from https://github.com/tc39/proposal-change-array-by-copy/pull/60.