### PR TITLE
toSpliced matches splice TypeError logic

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -204,6 +204,9 @@
             const o = toObject(this);
             const len = lengthOfArrayLike(o);
             const { actualStart, actualDeleteCount, newLen } = calculateSplice({ start, deleteCount, len, values, argsCount: arguments.length });
+            if (newLen > Number.MAX_SAFE_INTEGER) {
+                throw new TypeError();
+            }
             const a = new Array(newLen);
             doSplice({ src: o, target: a, actualStart, actualDeleteCount, values, newLen });
             return a;

--- a/spec.html
+++ b/spec.html
@@ -86,6 +86,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _dc_ be ? ToIntegerOrInfinity(_deleteCount_).
                         1. Let _actualDeleteCount_ be the result of clamping _dc_ between 0 and _len_ - _actualStart_.
                     1. Let _newLen_ be _len_ + _insertCount_ - _actualDeleteCount_.
+                    1. If _newLen_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
                     1. Let _A_ be ? ArrayCreate(𝔽(_newLen_)).
                     1. Let _k_ be 0.
                     1. Repeat, while _k_ &lt; _actualStart_,


### PR DESCRIPTION
Fixes #54 

`toSpliced` now throws a `TypeError` when the array length exceeds `MAX_SAFE_INTEGER`, matching the check in `splice`.

test262 PR merged: https://github.com/nicolo-ribaudo/test262/pull/1
