### PR TITLE
Adds note for why 'with' is not in unscopables

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -154,6 +154,9 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Return _unscopableList_.
                 </emu-alg>
                 <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+                <emu-note>
+                    <p>The reason that *"with"* is not included in the _unscopableList_ is because it is already a <emu-xref href="#sec-keywords-and-reserved-words">reserved word</emu-xref>.</p>
+                </emu-note>
             </emu-clause>
         </emu-clause>
     </emu-clause>


### PR DESCRIPTION
Adds a note for why `with` has not been added to `unscopables` as it is not immediately obvious otherwise as per https://github.com/tc39/proposal-change-array-by-copy/issues/74#issuecomment-1011560067