### PR TITLE
Update sorting methods to use abstract closures

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43,7 +43,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. <del>Return *+0*<sub>𝔽</sub>.</del>
                     1. <ins>Return ? CompareArrayElements(_x_, _y_, _comparefn_).</ins>
                 1. <del>Return ? SortIndexedProperties(_obj_, _len_, _SortCompare_).</del>
-                1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).</ins>
+                1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).</ins>
                 1. <ins>Let _itemCount_ be the number of elements in _sortedList_.</ins>
                 1. <ins>Let _j_ be 0.</ins>
                 1. <ins>Repeat, while _j_ &lt; _itemCount_,</ins>
@@ -90,7 +90,7 @@ contributors: Robin Ricard, Ashley Claymore
                     _obj_: an Object,
                     _len_: a non-negative integer,
                     _SortCompare_: an Abstract Closure with two parameters,
-                    <ins>_checkHasProperty_: a Boolean</ins>
+                    <ins>_ignoreHoles_: a Boolean</ins>
                   ): either a normal completion containing <del>an Object</del><ins>a List</ins> or an abrupt completion
                 </h1>
                 <dl class="header">
@@ -101,7 +101,7 @@ contributors: Robin Ricard, Ashley Claymore
                   1. Repeat, while _k_ &lt; _len_,
                     1. Let _Pk_ be ! ToString(𝔽(_k_)).
                     1. <del>Let _kPresent_ be ? HasProperty(_obj_, _Pk_).</del>
-                    1. <ins>If _checkHasProperty_ is *true*, then</ins>
+                    1. <ins>If _ignoreHoles_ is *false*, then</ins>
                         1. <ins>Let _kRead_ be ? HasProperty(_obj_, _Pk_).</ins>
                     1. <ins>Else,</ins>
                         1. <ins>Let _kRead_ be *true*.</ins>
@@ -154,7 +154,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
                         1. Return ? CompareArrayElements(_x_, _y_, _comparefn_).
-                    1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).
+                    1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).
                     1. Let _j_ be 0.
                     1. Repeat, while _j_ &lt; _len_,
                       1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_j_)), _sortedList_[_j_]).
@@ -323,7 +323,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. <del>Return *+0*<sub>𝔽</sub>.</del>
                         1. <ins>Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_, _buffer_).</ins>
                       1. <del>Return ? SortIndexedProperties(_obj_, _len_, _SortCompare_).</del>
-                      1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).</ins>
+                      1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).</ins>
                       1. <ins>Let _j_ be 0.</ins>
                       1. <ins>Repeat, while _j_ &lt; _len_,</ins>
                         1. <ins>Perform ! Set(_obj_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).</ins>
@@ -400,7 +400,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.toSorted"></emu-xref>.
                         1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and _buffer_ and performs the following steps when called:
                             1. Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_, _buffer_).
-                        1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).
+                        1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).
                         1. Let _j_ be 0.
                         1. Repeat, while _j_ &lt; _len_,
                           1. Perform ! Set(_A_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).

--- a/spec.html
+++ b/spec.html
@@ -104,8 +104,7 @@ contributors: Robin Ricard, Ashley Claymore
                   1. [id="step-array-sort"] Sort _items_ using an implementation-defined sequence of calls to _SortCompare_. If any such call returns an abrupt completion, stop before performing any further calls to _SortCompare_ or steps in this algorithm and return that Completion Record.
                   1. Let _j_ be 0.
                   1. Repeat, while _j_ &lt; _itemCount_,
-                    1. <del>Perform ? Set(_obj_, ! ToString(𝔽(_j_)), _items_[_j_], *true*).</del>
-                    1. <ins>Perform ? Set(_out_, ! ToString(𝔽(_j_)), _items_[_j_], *true*).</ins>
+                    1. Perform ? Set(<del>_obj_</del><ins>_out_</ins>, ! ToString(𝔽(_j_)), _items_[_j_], *true*).
                     1. Set _j_ to _j_ + 1.
                   1. <ins>Assert: If _checkHasProperty_ is *false* _j_ will now equal _len_.</ins>
                   1. Repeat, while _j_ &lt; _len_,
@@ -377,8 +376,8 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. Let _A_ be ? TypedArrayCreateSameType(_O_, &laquo; 𝔽(_len_) &raquo;).
                         1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.toSorted"></emu-xref>.
-                        1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and _buffer_ and performs the following steps when called:
-                            1. Return ? TypedArraySortComparison(_x_, _y_, _comparefn_).
+                        1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _compareFn__ and _buffer_ and performs the following steps when called:
+                            1. Return ? TypedArraySortComparison(_x_, _y_, _compareFn_).
                         1. Return ? SortIndexedProperties(_obj_, _A_, _len_, _SortCompare_, *false*).
                     </emu-alg>
                 </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -18,6 +18,102 @@ contributors: Robin Ricard, Ashley Claymore
         <emu-clause id="sec-properties-of-the-array-prototype-object">
             <h1>Properties of the Array Prototype Object</h1>
 
+            <emu-clause id="sec-array.prototype.sort" oldids="sec-sortcompare">
+                <h1>Array.prototype.sort ( _comparefn_ )</h1>
+
+                <p>When the `sort` method is called, the following steps are taken:</p>
+                <emu-alg>
+                1. [id="step-array-sort-comparefn"] If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+                1. Let _obj_ be ? ToObject(*this* value).
+                1. [id="step-array-sort-len"] Let _len_ be ? LengthOfArrayLike(_obj_).
+                1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
+                    1. <del>If _x_ and _y_ are both *undefined*, return *+0*<sub>𝔽</sub>.</del>
+                    1. <del>If _x_ is *undefined*, return *1*<sub>𝔽</sub>.</del>
+                    1. <del>If _y_ is *undefined*, return *-1*<sub>𝔽</sub>.</del>
+                    1. <del>If _comparefn_ is not *undefined*, then</del>
+                        1. <del>Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).</del>
+                        1. <del>If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.</del>
+                        1. <del>Return _v_.</del>
+                    1. <del>[id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).</del>
+                    1. <del>[id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).</del>
+                    1. <del>Let _xSmaller_ be ! IsLessThan(_xString_, _yString_, *true*).</del>
+                    1. <del>If _xSmaller_ is *true*, return *-1*<sub>𝔽</sub>.</del>
+                    1. <del>Let _ySmaller_ be ! IsLessThan(_yString_, _xString_, *true*).</del>
+                    1. <del>If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.</del>
+                    1. <del>Return *+0*<sub>𝔽</sub>.</del>
+                    1. <ins>Return ? ArraySortComparison(_x_, _y_, _comparefn_).</ins>
+                1. Return ? SortIndexedProperties(_obj_, <ins>_obj_</ins>, _len_, _SortCompare_, <ins>*true*</ins>).
+                </emu-alg>
+            </emu-clause>
+
+            <emu-clause id="sec-arraysortcomparison" type="abstract operation">
+                <h1>
+                  ArraySortComparison(
+                    _x_: unknown,
+                    _y_: unknown,
+                    _comparefn_: unknown
+                  ): either a normal completion containing a Number or an abrupt completion
+                </h1>
+                <dl class="header">
+                </dl>
+                <emu-alg>
+                    1. If _x_ and _y_ are both *undefined*, return *+0*<sub>𝔽</sub>.
+                    1. If _x_ is *undefined*, return *1*<sub>𝔽</sub>.
+                    1. If _y_ is *undefined*, return *-1*<sub>𝔽</sub>.
+                    1. If _comparefn_ is not *undefined*, then
+                        1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
+                        1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
+                        1. Return _v_.
+                    1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
+                    1. [id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).
+                    1. Let _xSmaller_ be ! IsLessThan(_xString_, _yString_, *true*).
+                    1. If _xSmaller_ is *true*, return *-1*<sub>𝔽</sub>.
+                    1. Let _ySmaller_ be ! IsLessThan(_yString_, _xString_, *true*).
+                    1. If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.
+                    1. Return *+0*<sub>𝔽</sub>.
+                </emu-alg>
+            </emu-clause>
+
+            <emu-clause id="sec-sortindexedproperties" type="abstract operation">
+                <h1>
+                  SortIndexedProperties (
+                    _obj_: an Object,
+                    <ins>_out_: an Object,</ins>
+                    _len_: a non-negative integer,
+                    _SortCompare_: an Abstract Closure with two parameters,
+                    <ins>_checkHasProperty_: a Boolean</ins>
+                  ): either a normal completion containing an Object or an abrupt completion
+                </h1>
+                <dl class="header">
+                </dl>
+                <emu-alg>
+                  1. Let _items_ be a new empty List.
+                  1. Let _k_ be 0.
+                  1. Repeat, while _k_ &lt; _len_,
+                    1. Let _Pk_ be ! ToString(𝔽(_k_)).
+                    1. <del>Let _kPresent_ be ? HasProperty(_obj_, _Pk_).</del>
+                    1. <ins>If _checkHasProperty_ is *true*, then</ins>
+                        1. <ins>Let _kRead_ be ? HasProperty(_obj_, _Pk_).</ins>
+                    1. <ins>Else,</ins>
+                        1. <ins>Let _kRead_ be *true*.</ins>
+                    1. If <del>_kPresent_</del><ins>_kRead_</ins> is *true*, then
+                      1. Let _kValue_ be ? Get(_obj_, _Pk_).
+                      1. Append _kValue_ to _items_.
+                    1. Set _k_ to _k_ + 1.
+                  1. Let _itemCount_ be the number of elements in _items_.
+                  1. [id="step-array-sort"] Sort _items_ using an implementation-defined sequence of calls to _SortCompare_. If any such call returns an abrupt completion, stop before performing any further calls to _SortCompare_ or steps in this algorithm and return that Completion Record.
+                  1. Let _j_ be 0.
+                  1. Repeat, while _j_ &lt; _itemCount_,
+                    1. <del>Perform ? Set(_obj_, ! ToString(𝔽(_j_)), _items_[_j_], *true*).</del>
+                    1. <ins>Perform ? Set(_out_, ! ToString(𝔽(_j_)), _items_[_j_], *true*).</ins>
+                    1. Set _j_ to _j_ + 1.
+                  1. <ins>Assert: If _checkHasProperty_ is *false* _j_ will now equal _len_.</ins>
+                  1. Repeat, while _j_ &lt; _len_,
+                    1. Perform ? DeletePropertyOrThrow(<del>_obj_</del><ins>_out_</ins>, ! ToString(𝔽(_j_))).</del>
+                    1. Set _j_ to _j_ + 1.
+                  1. Return <del>_obj_</del><ins>_out_</ins>.
+                </emu-alg>
+
             <emu-clause id="sec-array.prototype.toReversed">
                 <h1>Array.prototype.toReversed ( )</h1>
 
@@ -48,20 +144,9 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
                     1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
-                    1. Let _items_ be a new empty List.
-                    1. Let _k_ be 0.
-                    1. Repeat, while _k_ &lt; _len_,
-                        1. Let _Pk_ be ! ToString(𝔽(_k_)).
-                        1. Let _kValue_ be ? Get(_O_, _Pk_).
-                        1. Append _kValue_ to _items_.
-                        1. Set _k_ to _k_ + 1.
-                    1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
-                    1. Let _j_ be 0.
-                    1. For each element _E_ of _items_, do
-                        1. Let _Pj_ be ! ToString(𝔽(_j_)).
-                        1. Perform ! CreateDataPropertyOrThrow(_A_, _Pj_, _E_).
-                        1. Set _j_ to _j_ + 1.
-                    1. Return _A_.
+                    1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _compareFn_ and performs the following steps when called:
+                        1. Return ? ArraySortComparison(_x_, _y_, _compareFn_).
+                    1. Return ? SortIndexedProperties(_obj_, _A_, _len_, _SortCompare_, *false*).
                 </emu-alg>
             </emu-clause>
 
@@ -197,6 +282,68 @@ contributors: Robin Ricard, Ashley Claymore
             <emu-clause id="sec-properties-of-the-%typedarrayprototype%-object">
                 <h1>Properties of the %TypedArray% Prototype Object</h1>
 
+                <emu-clause id="sec-%typedarray%.prototype.sort" oldids="sec-typedarraysortcompare">
+                    <h1>%TypedArray%.prototype.sort ( _comparefn_ )</h1>
+
+                    <p>The following steps are performed:</p>
+                    <emu-alg>
+                      1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+                      1. Let _obj_ be the *this* value.
+                      1. Perform ? ValidateTypedArray(_obj_).
+                      1. Let _buffer_ be _obj_.[[ViewedArrayBuffer]].
+                      1. Let _len_ be _obj_.[[ArrayLength]].
+                      1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.
+                      1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and _buffer_ and performs the following steps when called:
+                        1. <del>Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.</del>
+                        1. <del>If _comparefn_ is not *undefined*, then</del>
+                          1. <del>Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).</del>
+                          1. <del>If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.</del>
+                          1. <del>If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.</del>
+                          1. <del>Return _v_.</del>
+                        1. <del>If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.</del>
+                        1. <del>If _x_ is *NaN*, return *1*<sub>𝔽</sub>.</del>
+                        1. <del>If _y_ is *NaN*, return *-1*<sub>𝔽</sub>.</del>
+                        1. <del>If _x_ &lt; _y_, return *-1*<sub>𝔽</sub>.</del>
+                        1. <del>If _x_ &gt; _y_, return *1*<sub>𝔽</sub>.</del>
+                        1. <del>If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.</del>
+                        1. <del>If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.</del>
+                        1. <del>Return *+0*<sub>𝔽</sub>.</del>
+                        1. <ins>Return ? TypedArraySortComparison(_x_, _y_, _comparefn_).</ins>
+                      1. Return ? SortIndexedProperties(_obj_, <ins>_obj_</ins>, _len_, _SortCompare_, <ins>*false*</ins>).
+                    </emu-alg>
+                </emu-clause>
+
+                <emu-clause id="sec-typedarraysortcomparison" type="abstract operation">
+                    <h1>
+                    TypedArraySortComparison(
+                        _x_: unknown,
+                        _y_: unknown,
+                        _comparefn_: unknown
+                    ): either a normal completion containing a Number or an abrupt completion
+                    </h1>
+                    <dl class="header">
+                    </dl>
+                    <emu-alg>
+                        1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
+                        1. If _comparefn_ is not *undefined*, then
+                            1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
+                            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+                            1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
+                            1. Return _v_.
+                        1. If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.
+                        1. If _x_ is *NaN*, return *1*<sub>𝔽</sub>.
+                        1. If _y_ is *NaN*, return *-1*<sub>𝔽</sub>.
+                        1. If _x_ &lt; _y_, return *-1*<sub>𝔽</sub>.
+                        1. If _x_ &gt; _y_, return *1*<sub>𝔽</sub>.
+                        1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
+                        1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+                        1. Return *+0*<sub>𝔽</sub>.
+                    </emu-alg>
+                    <emu-note>
+                        This performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-arraysortcomparison"></emu-xref>.
+                    </emu-note>
+                </emu-clause>
+
                 <emu-clause id="sec-%typedarray%.prototype.toReversed">
                     <h1>%TypedArray%.prototype.toReversed ( )</h1>
 
@@ -229,38 +376,10 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Perform ? ValidateTypedArray(_O_).
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. Let _A_ be ? TypedArrayCreateSameType(_O_, &laquo; 𝔽(_len_) &raquo;).
-                        1. Let _items_ be a new empty List.
-                        1. Let _k_ be 0.
-                        1. Repeat, while _k_ &lt; _len_,
-                            1. Let _Pk_ be ! ToString(𝔽(_k_)).
-                            1. Let _kValue_ be ! Get(_O_, _Pk_).
-                            1. Append _kValue_ to _items_.
-                            1. Set _k_ to _k_ + 1.
-                        1. Sort _items_ using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that completion.
-                        1. Let _j_ be 0.
-                        1. For each element _E_ of _items_, do
-                            1. Let _Pj_ be ! ToString(𝔽(_j_)).
-                            1. Perform ! Set(_A_, _Pj_, _E_, *true*).
-                            1. Set _j_ to _j_ + 1.
-                        1. Return _A_.
-                    </emu-alg>
-                    <p>The following version of SortCompare is used by %TypedArray%`.prototype.toSorted`.</p>
-                    <p>The abstract operation TypedArraySortCompare performs the following steps when called:</p>
-                    <emu-alg>
-                        1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
-                        1. If _comparefn_ is not *undefined*, then
-                            1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
-                            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-                            1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
-                            1. Return _v_.
-                        1. If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.
-                        1. If _x_ is *NaN*, return *1*<sub>𝔽</sub>.
-                        1. If _y_ is *NaN*, return *-1*<sub>𝔽</sub>.
-                        1. If _x_ &lt; _y_, return *-1*<sub>𝔽</sub>.
-                        1. If _x_ &gt; _y_, return *1*<sub>𝔽</sub>.
-                        1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
-                        1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
-                        1. Return *+0*<sub>𝔽</sub>.
+                        1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.toSorted"></emu-xref>.
+                        1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and _buffer_ and performs the following steps when called:
+                            1. Return ? TypedArraySortComparison(_x_, _y_, _comparefn_).
+                        1. Return ? SortIndexedProperties(_obj_, _A_, _len_, _SortCompare_, *false*).
                     </emu-alg>
                 </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -43,12 +43,13 @@ contributors: Robin Ricard, Ashley Claymore
                     1. <del>Return *+0*<sub>𝔽</sub>.</del>
                     1. <ins>Return ? CompareArrayElements(_x_, _y_, _comparefn_).</ins>
                 1. <del>Return ? SortIndexedProperties(_obj_, _len_, _SortCompare_).</del>
-                1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).</ins>
+                1. [id="step-array-sortindexedproperties"] <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).</ins>
                 1. <ins>Let _itemCount_ be the number of elements in _sortedList_.</ins>
                 1. <ins>Let _j_ be 0.</ins>
                 1. <ins>Repeat, while _j_ &lt; _itemCount_,</ins>
                   1. <ins>Perform ? CreateDataPropertyOrThrow(_obj_, ! ToString(𝔽(_j_)), _sortedList_[_j_]).</ins>
                   1. <ins>Set _j_ to _j_ + 1.</ins>
+                1. <ins>NOTE: The call to SortIndexedProperties in step <emu-xref href="#step-array-sortindexedproperties"></emu-xref> has the *skipHoles* parameter set to *true*. The remaining indexes are deleted to preserve the number of holes that were detected and excluded from the sort.</ins>
                 1. <ins>Repeat, while _j_ &lt; _len_,</ins>
                   1. <ins>Perform ? DeletePropertyOrThrow(_obj_, ! ToString(𝔽(_j_))).</ins>
                   1. <ins>Set _j_ to _j_ + 1.</ins>
@@ -90,7 +91,7 @@ contributors: Robin Ricard, Ashley Claymore
                     _obj_: an Object,
                     _len_: a non-negative integer,
                     _SortCompare_: an Abstract Closure with two parameters,
-                    <ins>_ignoreHoles_: a Boolean</ins>
+                    <ins>_skipHoles_: a Boolean</ins>
                   ): either a normal completion containing <del>an Object</del><ins>a List</ins> or an abrupt completion
                 </h1>
                 <dl class="header">
@@ -101,7 +102,7 @@ contributors: Robin Ricard, Ashley Claymore
                   1. Repeat, while _k_ &lt; _len_,
                     1. Let _Pk_ be ! ToString(𝔽(_k_)).
                     1. <del>Let _kPresent_ be ? HasProperty(_obj_, _Pk_).</del>
-                    1. <ins>If _ignoreHoles_ is *false*, then</ins>
+                    1. <ins>If _skipHoles_ is *true*, then</ins>
                         1. <ins>Let _kRead_ be ? HasProperty(_obj_, _Pk_).</ins>
                     1. <ins>Else,</ins>
                         1. <ins>Let _kRead_ be *true*.</ins>
@@ -121,6 +122,7 @@ contributors: Robin Ricard, Ashley Claymore
                   1. <del>Return _obj_.</del>
                   1. <ins>Return _items_.</ins>
                 </emu-alg>
+            </emu-clause>
 
             <emu-clause id="sec-array.prototype.toReversed">
                 <h1>Array.prototype.toReversed ( )</h1>
@@ -154,7 +156,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
                         1. Return ? CompareArrayElements(_x_, _y_, _comparefn_).
-                    1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).
+                    1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).
                     1. Let _j_ be 0.
                     1. Repeat, while _j_ &lt; _len_,
                       1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_j_)), _sortedList_[_j_]).
@@ -323,7 +325,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. <del>Return *+0*<sub>𝔽</sub>.</del>
                         1. <ins>Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_, _buffer_).</ins>
                       1. <del>Return ? SortIndexedProperties(_obj_, _len_, _SortCompare_).</del>
-                      1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).</ins>
+                      1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).</ins>
                       1. <ins>Let _j_ be 0.</ins>
                       1. <ins>Repeat, while _j_ &lt; _len_,</ins>
                         1. <ins>Perform ! Set(_obj_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).</ins>
@@ -400,7 +402,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.toSorted"></emu-xref>.
                         1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and _buffer_ and performs the following steps when called:
                             1. Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_, _buffer_).
-                        1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).
+                        1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).
                         1. Let _j_ be 0.
                         1. Repeat, while _j_ &lt; _len_,
                           1. Perform ! Set(_A_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).

--- a/spec.html
+++ b/spec.html
@@ -61,7 +61,7 @@ contributors: Robin Ricard, Ashley Claymore
                   CompareArrayElements(
                     _x_: unknown,
                     _y_: unknown,
-                    _comparefn_: unknown
+                    _comparefn_: a function object or *undefined*
                   ): either a normal completion containing a Number or an abrupt completion
                 </h1>
                 <dl class="header">
@@ -337,7 +337,7 @@ contributors: Robin Ricard, Ashley Claymore
                     CompareTypedArrayElements(
                         _x_: unknown,
                         _y_: unknown,
-                        _comparefn_: unknown,
+                        _comparefn_: a function object or *undefined*,
                         _buffer_: An ArrayBuffer
                     ): either a normal completion containing a Number or an abrupt completion
                     </h1>

--- a/spec.html
+++ b/spec.html
@@ -42,7 +42,17 @@ contributors: Robin Ricard, Ashley Claymore
                     1. <del>If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.</del>
                     1. <del>Return *+0*<sub>𝔽</sub>.</del>
                     1. <ins>Return ? CompareArrayElements(_x_, _y_, _comparefn_).</ins>
-                1. Return ? SortIndexedProperties(_obj_, <ins>_obj_</ins>, _len_, _SortCompare_, <ins>*true*</ins>).
+                1. <del>Return ? SortIndexedProperties(_obj_, _len_, _SortCompare_).</del>
+                1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *true*).</ins>
+                1. <ins>Let _itemCount_ be the number of elements in _sortedList_.</ins>
+                1. <ins>Let _j_ be 0.</ins>
+                1. <ins>Repeat, while _j_ &lt; _itemCount_,</ins>
+                  1. <ins>Perform ? CreateDataPropertyOrThrow(_obj_, ! ToString(𝔽(_j_)), _sortedList_[_j_]).</ins>
+                  1. <ins>Set _j_ to _j_ + 1.</ins>
+                1. <ins>Repeat, while _j_ &lt; _len_,</ins>
+                  1. <ins>Perform ? DeletePropertyOrThrow(_obj_, ! ToString(𝔽(_j_))).</ins>
+                  1. <ins>Set _j_ to _j_ + 1.</ins>
+                1. <ins>Return _obj_.</ins>
                 </emu-alg>
             </emu-clause>
 
@@ -78,11 +88,10 @@ contributors: Robin Ricard, Ashley Claymore
                 <h1>
                   SortIndexedProperties (
                     _obj_: an Object,
-                    <ins>_out_: an Object,</ins>
                     _len_: a non-negative integer,
                     _SortCompare_: an Abstract Closure with two parameters,
                     <ins>_checkHasProperty_: a Boolean</ins>
-                  ): either a normal completion containing an Object or an abrupt completion
+                  ): either a normal completion containing <del>an Object</del><ins>a List</ins> or an abrupt completion
                 </h1>
                 <dl class="header">
                 </dl>
@@ -100,17 +109,17 @@ contributors: Robin Ricard, Ashley Claymore
                       1. Let _kValue_ be ? Get(_obj_, _Pk_).
                       1. Append _kValue_ to _items_.
                     1. Set _k_ to _k_ + 1.
-                  1. Let _itemCount_ be the number of elements in _items_.
+                  1. <del>Let _itemCount_ be the number of elements in _items_.</del>
                   1. [id="step-array-sort"] Sort _items_ using an implementation-defined sequence of calls to _SortCompare_. If any such call returns an abrupt completion, stop before performing any further calls to _SortCompare_ or steps in this algorithm and return that Completion Record.
-                  1. Let _j_ be 0.
-                  1. Repeat, while _j_ &lt; _itemCount_,
-                    1. Perform ? Set(<del>_obj_</del><ins>_out_</ins>, ! ToString(𝔽(_j_)), _items_[_j_], *true*).
-                    1. Set _j_ to _j_ + 1.
-                  1. <ins>Assert: If _checkHasProperty_ is *false* _j_ will now equal _len_.</ins>
-                  1. Repeat, while _j_ &lt; _len_,
-                    1. Perform ? DeletePropertyOrThrow(<del>_obj_</del><ins>_out_</ins>, ! ToString(𝔽(_j_))).</del>
-                    1. Set _j_ to _j_ + 1.
-                  1. Return <del>_obj_</del><ins>_out_</ins>.
+                  1. <del>Let _j_ be 0.</del>
+                  1. <del>Repeat, while _j_ &lt; _itemCount_,</del>
+                    1. <del>Perform ? Set(_obj_, ! ToString(𝔽(_j_)), _items_[_j_], *true*).</del>
+                    1. <del>Set _j_ to _j_ + 1.</del>
+                  1. <del>Repeat, while _j_ &lt; _len_,</del>
+                    1. <del>Perform ? DeletePropertyOrThrow(_obj_, ! ToString(𝔽(_j_))).</del>
+                    1. <del>Set _j_ to _j_ + 1.</del>
+                  1. <del>Return _obj_.</del>
+                  1. <ins>Return _items_.</ins>
                 </emu-alg>
 
             <emu-clause id="sec-array.prototype.toReversed">
@@ -134,7 +143,7 @@ contributors: Robin Ricard, Ashley Claymore
             </emu-clause>
 
             <emu-clause id="sec-array.prototype.toSorted">
-                <h1>Array.prototype.toSorted ( _compareFn_ )</h1>
+                <h1>Array.prototype.toSorted ( _comparefn_ )</h1>
 
                 <p>When the *toSorted* method is called, the following steps are taken:</p>
 
@@ -143,9 +152,14 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _O_ be ? ToObject(*this* value).
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
                     1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
-                    1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _compareFn_ and performs the following steps when called:
-                        1. Return ? CompareArrayElements(_x_, _y_, _compareFn_).
-                    1. Return ? SortIndexedProperties(_obj_, _A_, _len_, _SortCompare_, *false*).
+                    1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
+                        1. Return ? CompareArrayElements(_x_, _y_, _comparefn_).
+                    1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).
+                    1. Let _j_ be 0.
+                    1. Repeat, while _j_ &lt; _len_,
+                      1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_j_)), _sortedList_[_j_]).
+                      1. Set _j_ to _j_ + 1.
+                    1. Return _A_.
                 </emu-alg>
             </emu-clause>
 
@@ -307,8 +321,14 @@ contributors: Robin Ricard, Ashley Claymore
                         1. <del>If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.</del>
                         1. <del>If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.</del>
                         1. <del>Return *+0*<sub>𝔽</sub>.</del>
-                        1. <ins>Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_).</ins>
-                      1. Return ? SortIndexedProperties(_obj_, <ins>_obj_</ins>, _len_, _SortCompare_, <ins>*false*</ins>).
+                        1. <ins>Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_, _buffer_).</ins>
+                      1. <del>Return ? SortIndexedProperties(_obj_, _len_, _SortCompare_).</del>
+                      1. <ins>Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).</ins>
+                      1. <ins>Let _j_ be 0.</ins>
+                      1. <ins>Repeat, while _j_ &lt; _len_,</ins>
+                        1. <ins>Perform ! Set(_obj_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).</ins>
+                        1. <ins>Set _j_ to _j_ + 1.</ins>
+                      1. <ins>Return _obj_.</ins>
                     </emu-alg>
                 </emu-clause>
 
@@ -317,7 +337,8 @@ contributors: Robin Ricard, Ashley Claymore
                     CompareTypedArrayElements(
                         _x_: unknown,
                         _y_: unknown,
-                        _comparefn_: unknown
+                        _comparefn_: unknown,
+                        _buffer_: An ArrayBuffer
                     ): either a normal completion containing a Number or an abrupt completion
                     </h1>
                     <dl class="header">
@@ -365,7 +386,7 @@ contributors: Robin Ricard, Ashley Claymore
                 </emu-clause>
 
                 <emu-clause id="sec-%typedarray%.prototype.toSorted">
-                    <h1>%TypedArray%.prototype.toSorted ( _compareFn_ )</h1>
+                    <h1>%TypedArray%.prototype.toSorted ( _comparefn_ )</h1>
 
                     <p>When the *toSorted* method is called, the following steps are taken:</p>
 
@@ -373,12 +394,18 @@ contributors: Robin Ricard, Ashley Claymore
                         1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
                         1. Let _O_ be the *this* value.
                         1. Perform ? ValidateTypedArray(_O_).
+                        1. Let _buffer_ be _obj_.[[ViewedArrayBuffer]].
                         1. Let _len_ be _O_.[[ArrayLength]].
                         1. Let _A_ be ? TypedArrayCreateSameType(_O_, &laquo; 𝔽(_len_) &raquo;).
                         1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.toSorted"></emu-xref>.
-                        1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _compareFn__ and _buffer_ and performs the following steps when called:
-                            1. Return ? CompareTypedArrayElements(_x_, _y_, _compareFn_).
-                        1. Return ? SortIndexedProperties(_obj_, _A_, _len_, _SortCompare_, *false*).
+                        1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and _buffer_ and performs the following steps when called:
+                            1. Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_, _buffer_).
+                        1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, *false*).
+                        1. Let _j_ be 0.
+                        1. Repeat, while _j_ &lt; _len_,
+                          1. Perform ! Set(_A_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).
+                          1. Set _j_ to _j_ + 1.
+                        1. Return _A_.
                     </emu-alg>
                 </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -41,14 +41,14 @@ contributors: Robin Ricard, Ashley Claymore
                     1. <del>Let _ySmaller_ be ! IsLessThan(_yString_, _xString_, *true*).</del>
                     1. <del>If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.</del>
                     1. <del>Return *+0*<sub>𝔽</sub>.</del>
-                    1. <ins>Return ? ArraySortComparison(_x_, _y_, _comparefn_).</ins>
+                    1. <ins>Return ? CompareArrayElements(_x_, _y_, _comparefn_).</ins>
                 1. Return ? SortIndexedProperties(_obj_, <ins>_obj_</ins>, _len_, _SortCompare_, <ins>*true*</ins>).
                 </emu-alg>
             </emu-clause>
 
-            <emu-clause id="sec-arraysortcomparison" type="abstract operation">
+            <emu-clause id="sec-comparearrayelements" type="abstract operation">
                 <h1>
-                  ArraySortComparison(
+                  CompareArrayElements(
                     _x_: unknown,
                     _y_: unknown,
                     _comparefn_: unknown
@@ -144,7 +144,7 @@ contributors: Robin Ricard, Ashley Claymore
                     1. Let _len_ be ? LengthOfArrayLike(_O_).
                     1. Let _A_ be ? ArrayCreate(𝔽(_len_)).
                     1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _compareFn_ and performs the following steps when called:
-                        1. Return ? ArraySortComparison(_x_, _y_, _compareFn_).
+                        1. Return ? CompareArrayElements(_x_, _y_, _compareFn_).
                     1. Return ? SortIndexedProperties(_obj_, _A_, _len_, _SortCompare_, *false*).
                 </emu-alg>
             </emu-clause>
@@ -307,14 +307,14 @@ contributors: Robin Ricard, Ashley Claymore
                         1. <del>If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.</del>
                         1. <del>If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.</del>
                         1. <del>Return *+0*<sub>𝔽</sub>.</del>
-                        1. <ins>Return ? TypedArraySortComparison(_x_, _y_, _comparefn_).</ins>
+                        1. <ins>Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_).</ins>
                       1. Return ? SortIndexedProperties(_obj_, <ins>_obj_</ins>, _len_, _SortCompare_, <ins>*false*</ins>).
                     </emu-alg>
                 </emu-clause>
 
-                <emu-clause id="sec-typedarraysortcomparison" type="abstract operation">
+                <emu-clause id="sec-comparetypedarrayelements" type="abstract operation">
                     <h1>
-                    TypedArraySortComparison(
+                    CompareTypedArrayElements(
                         _x_: unknown,
                         _y_: unknown,
                         _comparefn_: unknown
@@ -339,7 +339,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Return *+0*<sub>𝔽</sub>.
                     </emu-alg>
                     <emu-note>
-                        This performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-arraysortcomparison"></emu-xref>.
+                        This performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-comparearrayelements"></emu-xref>.
                     </emu-note>
                 </emu-clause>
 
@@ -377,7 +377,7 @@ contributors: Robin Ricard, Ashley Claymore
                         1. Let _A_ be ? TypedArrayCreateSameType(_O_, &laquo; 𝔽(_len_) &raquo;).
                         1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.toSorted"></emu-xref>.
                         1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _compareFn__ and _buffer_ and performs the following steps when called:
-                            1. Return ? TypedArraySortComparison(_x_, _y_, _compareFn_).
+                            1. Return ? CompareTypedArrayElements(_x_, _y_, _compareFn_).
                         1. Return ? SortIndexedProperties(_obj_, _A_, _len_, _SortCompare_, *false*).
                     </emu-alg>
                 </emu-clause>


### PR DESCRIPTION
Updating `toSorted` now that https://github.com/tc39/ecma262/pull/2305 has merged upstream.

Replaces #69 and fixes #51 

cc: @michaelficarra  @bakkot @jmdyck